### PR TITLE
Loosen asyncstorage-down version to allow 4.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     "levelup": "^0.18.2"
   },
   "peerDependencies": {
-    "asyncstorage-down": "^3.0.0"
+    "asyncstorage-down": ">=3.0.0 <5.0.0"
   }
 }


### PR DESCRIPTION
This is the current version as of July, 2017.
https://github.com/tradle/asyncstorage-down/commits/master